### PR TITLE
Add rust-lld symlink to toolchain

### DIFF
--- a/packages/rust-xous-toolchain.scm
+++ b/packages/rust-xous-toolchain.scm
@@ -370,11 +370,17 @@ targets for Xous development.")
                           (when (file-exists? source)
                             (symlink source target))))
                       '("rustfmt" "cargo-fmt" "clippy-driver" "cargo-clippy"
-                        "rust-analyzer" "rustdoc"))))))
+                        "rust-analyzer" "rustdoc"))
+
+            ;; Create rust-lld symlink (rustc's gnu-lld linker flavor needs this name)
+            (let ((lld (assoc-ref %build-inputs "lld")))
+              (symlink (string-append lld "/bin/ld.lld")
+                       (string-append bin-dir "/rust-lld")))))))
     (inputs `(("rust" ,%rust)
               ("rust:cargo" ,%rust "cargo")
               ("rust-sysroot-merged" ,rust-sysroot-merged)
               ("gcc-toolchain" ,gcc-toolchain)
+              ("lld" ,lld-18)
               ("bash-minimal" ,bash-minimal)))
     ;; Propagate linkers from sysroot packages
     (propagated-inputs


### PR DESCRIPTION
## Summary
- Adds a `rust-lld` symlink (pointing to `ld.lld` from `lld-18`) in the `rust-xous-toolchain` package
- Fixes `error: linker 'rust-lld' not found` in dev shells (`guix shell -m manifest.scm`)
- Matches what rustup does: provides `rust-lld` as a symlink to `lld`

## Context
Rustc's built-in target specs for `riscv32imac-unknown-none-elf` and `riscv32imac-unknown-xous-elf` specify `"linker": "rust-lld"`. The Guix-built toolchain provided `ld.lld` via propagated `lld-18` but not the `rust-lld` name that rustc looks for. This worked in `guix build` contexts but failed in dev shells.

## Test plan
- [x] `guix time-machine -C guix/channels.scm -- shell -m guix/manifest.scm` enters without error
- [x] `which rust-lld` shows the profile path
- [x] `ld.lld --version` shows LLD 18.x
- [x] `cargo xtask bao1x-boot0 --no-verify` links successfully