### PR TITLE
tools: unpin rustfilt from rust-1.90

### DIFF
--- a/packages/tools.scm
+++ b/packages/tools.scm
@@ -21,7 +21,14 @@
   #:use-module (gnu packages base)
   #:use-module (gnu packages compression)
   #:use-module (gnu packages rust)
+  #:use-module (xous-config)
   #:export (rustfilt riscv32-none-elf-binutils elf-analyzer))
+
+;; Resolve %rust-version string to actual rust package, like the other
+;; modules — avoids hardcoding a Rust version that may be dropped upstream.
+(define %rust
+  (module-ref (resolve-module '(gnu packages rust))
+              (string->symbol (string-append "rust-" %rust-version))))
 
 ;;; =============================================================
 ;;; CRATE SOURCES (generated via guix import crate -f Cargo.lock)
@@ -175,8 +182,8 @@
               (let ((bin (string-append (assoc-ref outputs "out") "/bin")))
                 (mkdir-p bin)
                 (install-file "target/release/rustfilt" bin)))))))
-    (native-inputs `(("rust" ,rust-1.90)
-                     ("rust:cargo" ,rust-1.90 "cargo")
+    (native-inputs `(("rust" ,%rust)
+                     ("rust:cargo" ,%rust "cargo")
                      ("tar" ,tar)
                      ("gzip" ,gzip)
                      ("coreutils" ,coreutils)


### PR DESCRIPTION
Problem: rustfilt hardcoded rust-1.90 in its native-inputs while every other module resolves %rust from %rust-version (currently 1.93). This is a latent eval-time breakage -- the channel stops evaluating once upstream Guix drops rust-1.90 -- and builds this host tool against a different compiler than the rest of the channel.

Solution: import (xous-config) and resolve %rust from %rust-version the same way embedded.scm and rust-xous-toolchain.scm do. Only affects the -report tool, not firmware output.