### PR TITLE
ci: fetch guix channel from fork, add cache 

### DIFF
--- a/.github/actions/setup-guix/action.yml
+++ b/.github/actions/setup-guix/action.yml
@@ -1,0 +1,39 @@
+name: Set up Guix
+description: >-
+  Install Guix, restore the time-machine channel checkout cache, and authorize
+  the baobit substitute servers.  Used by every workflow that runs
+  `guix time-machine`, so the cache and authorization live in one place.
+
+inputs:
+  version:
+    description: Guix version to install
+    default: "1.5.0"
+
+runs:
+  using: composite
+  steps:
+    # Cache the guix time-machine channel checkout (~/.cache/guix/checkouts).
+    # On a cache hit the pinned commit is already present, so time-machine skips
+    # the channel git fetch entirely -- no dependency on the upstream Git host
+    # being reachable.  Keyed on the channel files so a pin bump busts it; the
+    # restore-keys prefix lets a bump reuse the previous warm checkout and fetch
+    # only the delta instead of re-cloning ~1 GB.
+    - name: Cache Guix channel checkout
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/guix
+        key: guix-tm-${{ runner.os }}-${{ hashFiles('channels/*.scm') }}
+        restore-keys: |
+          guix-tm-${{ runner.os }}-
+
+    - name: Install Guix
+      uses: sbellem/guix-install-action@dev
+      with:
+        version: ${{ inputs.version }}
+        pullAfterInstall: false
+
+    - name: Authorize substitute servers
+      shell: bash
+      run: |
+        sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
+        sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub

--- a/.github/actions/setup-guix/action.yml
+++ b/.github/actions/setup-guix/action.yml
@@ -12,19 +12,35 @@ inputs:
 runs:
   using: composite
   steps:
-    # Cache the guix time-machine channel checkout (~/.cache/guix/checkouts).
-    # On a cache hit the pinned commit is already present, so time-machine skips
-    # the channel git fetch entirely -- no dependency on the upstream Git host
-    # being reachable.  Keyed on the channel files so a pin bump busts it; the
-    # restore-keys prefix lets a bump reuse the previous warm checkout and fetch
-    # only the delta instead of re-cloning ~1 GB.
+    # Resolve the channel's keyring branch HEAD.  Guix authenticates a channel
+    # by checking each commit's signature against keys in the repo's `keyring`
+    # branch -- and it does NOT refresh that branch from a restored cache
+    # checkout.  So the keyring revision must be part of the cache key: otherwise
+    # a checkout cached with an old keyring is reused and authentication fails
+    # even after the keyring is fixed upstream (exactly what bit us once).
+    - name: Resolve channel keyring revision
+      id: keyring
+      shell: bash
+      run: |
+        url=$(sed -n 's/.*(url "\(https:[^"]*\)").*/\1/p' channels/guix.scm | head -1)
+        sha=$(git ls-remote "$url" refs/heads/keyring 2>/dev/null | awk '{print $1}')
+        echo "channel=$url keyring=${sha:-none}"
+        echo "sha=${sha:-none}" >> "$GITHUB_OUTPUT"
+
+    # Cache the guix time-machine channel checkout (~/.cache/guix).  On a hit the
+    # pinned commit and keyring are already present, so time-machine skips the
+    # channel git fetch entirely -- no dependency on the upstream Git host being
+    # reachable.  The key includes the keyring revision (correctness) and the
+    # channel files (pin bumps); restore-keys is scoped to the same keyring
+    # revision, so a pin bump can still reuse a warm checkout but a stale keyring
+    # can never be restored.
     - name: Cache Guix channel checkout
       uses: actions/cache@v4
       with:
         path: ~/.cache/guix
-        key: guix-tm-${{ runner.os }}-${{ hashFiles('channels/*.scm') }}
+        key: guix-tm-${{ runner.os }}-k${{ steps.keyring.outputs.sha }}-${{ hashFiles('channels/*.scm') }}
         restore-keys: |
-          guix-tm-${{ runner.os }}-
+          guix-tm-${{ runner.os }}-k${{ steps.keyring.outputs.sha }}-
 
     - name: Install Guix
       uses: sbellem/guix-install-action@dev

--- a/.github/workflows/baosec.yml
+++ b/.github/workflows/baosec.yml
@@ -13,16 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build baosec
         timeout-minutes: 120

--- a/.github/workflows/bootloader.yml
+++ b/.github/workflows/bootloader.yml
@@ -17,16 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build bao1x-${{ matrix.target }}
         timeout-minutes: 120

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,16 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build rust-sysroot-riscv32imac-none-elf
         run: make CHANNELS=${{ matrix.channels }} ROOT=sysroot-none-elf rv32imac-none
@@ -71,16 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build rust-sysroot-riscv32imac-xous-elf
         run: make CHANNELS=${{ matrix.channels }} ROOT=sysroot-xous-elf rv32imac-xous
@@ -158,16 +142,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build rust-xous-toolchain
         run: make CHANNELS=${{ matrix.channels }} ROOT=rust-xous toolchain
@@ -245,16 +221,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build bao1x-boot0
         run: make CHANNELS=${{ matrix.channels }} ROOT=bao1x-boot0 boot0
@@ -310,16 +278,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build bao1x-boot1
         run: make CHANNELS=${{ matrix.channels }} ROOT=bao1x-boot1 boot1
@@ -375,16 +335,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build bao1x-alt-boot1
         run: make CHANNELS=${{ matrix.channels }} ROOT=bao1x-alt-boot1 alt-boot1
@@ -440,16 +392,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build bao1x-baremetal-dabao
         run: make CHANNELS=${{ matrix.channels }} ROOT=bao1x-baremetal-dabao baremetal-dabao
@@ -505,16 +449,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build dabao
         run: make CHANNELS=${{ matrix.channels }} ROOT=dabao dabao
@@ -570,16 +506,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build dabao-helloworld
         run: make CHANNELS=${{ matrix.channels }} ROOT=dabao-helloworld dabao-helloworld
@@ -635,16 +563,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build baosec
         run: make CHANNELS=${{ matrix.channels }} ROOT=baosec baosec

--- a/.github/workflows/dabao.yml
+++ b/.github/workflows/dabao.yml
@@ -21,16 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build ${{ matrix.root }}
         timeout-minutes: 120

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -13,16 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Dry-run all packages
         id: dry-run

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -69,16 +69,8 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build ${{ matrix.root }}
         run: make ROOT=${{ matrix.root }} ${{ matrix.target }}

--- a/.github/workflows/rust-xous-toolchain.yml
+++ b/.github/workflows/rust-xous-toolchain.yml
@@ -13,16 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build rust-sysroot-riscv32imac-none-elf
         timeout-minutes: 120
@@ -71,16 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build rust-sysroot-riscv32imac-xous-elf
         timeout-minutes: 120
@@ -129,16 +113,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Guix
-        uses: sbellem/guix-install-action@dev
-        with:
-          version: "1.5.0"
-          pullAfterInstall: false
-
-      - name: Authorize substitute servers
-        run: |
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/guix.baobit.one.pub
-          sudo /var/guix/profiles/per-user/root/current-guix/bin/guix archive --authorize < keys/ci.guix.moe.pub
+      - name: Set up Guix
+        uses: ./.github/actions/setup-guix
 
       - name: Build rust-xous-toolchain
         timeout-minutes: 120

--- a/channels/guix.scm
+++ b/channels/guix.scm
@@ -1,9 +1,16 @@
-;; Channels configuration for baobit (Codeberg mirror)
+;; Channels configuration for baobit (GitHub fork mirror)
 ;; Usage: guix time-machine --channels=channels/guix.scm -- build -L packages bao1x-boot0
+;;
+;; CI fetches the Guix channel from our own GitHub fork rather than
+;; codeberg.org: codeberg throttles/resets large clones under load (libgit2
+;; "Resource temporarily unavailable"), and the GitHub-hosted runners reach a
+;; GitHub remote over the intra-provider network reliably.  The commit below is
+;; an ancestor of the fork's master; channels/guix-savannah.scm mirrors the
+;; same commit.  Keep the fork's master in sync with upstream before bumping.
 
 (list (channel
         (name 'guix)
-        (url "https://codeberg.org/guix/guix.git")
+        (url "https://github.com/sbellem/guix.git")
         (branch "master")
         (commit "b5e047ff9b400585cff590b7ee2f1629b24f6148")
         (introduction


### PR DESCRIPTION
Problem: CI jobs fail intermittently while setting up Guix. guix time-machine clones the full Guix history from codeberg.org on every matrix job, and codeberg throttles or resets large clones under load, producing "Git error: SSL error: syscall failure: Resource temporarily unavailable". The retry action re-runs make, which re-clones from the same host, so all three attempts fail together.

Solution: Point channels/guix.scm at our GitHub fork (github.com/sbellem/guix); GitHub-hosted runners reach a GitHub remote over the intra-provider network reliably. Add a setup-guix composite action that caches ~/.cache/guix keyed on the channel files, so on a cache hit time-machine finds the pinned commit locally and skips the channel fetch entirely. Replace the duplicated install + authorize block across all time-machine workflows with the new action.