### PR TITLE
embedded: install .rmeta into bare-metal sysroot

### DIFF
--- a/packages/embedded.scm
+++ b/packages/embedded.scm
@@ -129,9 +129,14 @@
                        (dest-lib (string-append out "/lib/rustlib/" target
                                                 "/lib")))
                   (mkdir-p dest-lib)
+                  ;; Rust 1.94's bootstrap builds std with metadata stubs in
+                  ;; the rlibs and the real metadata in sibling .rmeta files
+                  ;; (a sysroot-size optimization).  Drop the .rmeta and any
+                  ;; cross-compile fails with "only metadata stub found for
+                  ;; rlib dependency core", so install it alongside the rlibs.
                   (for-each (lambda (f)
                               (install-file f dest-lib))
-                            (find-files src-lib "\\.(rlib|a)$")))))
+                            (find-files src-lib "\\.(rlib|rmeta|a)$")))))
             (delete 'wrap-rustc)
             (delete 'delete-install-logs)))))
     (native-inputs (modify-inputs (package-native-inputs %rust)


### PR DESCRIPTION
Problem: The Rust 1.94 bootstrap (x.py) builds std with metadata stubs in the .rlib files and the real metadata in sibling .rmeta files (a sysroot-size optimization; 1.93 and earlier embedded full metadata in the rlibs).  The install phase globbed only \\.(rlib|a)$ and dropped the .rmeta, so cross-compiling against the sysroot failed with "only metadata stub found for rlib dependency core".

Solution: Install the .rmeta alongside the rlibs by extending the glob to \\.(rlib|rmeta|a)$, matching a normal rustup sysroot layout.  A latent bug that only surfaced at 1.94.