### PR TITLE
refactor: auto-derive rust submodule pins

### DIFF
--- a/packages/rust-xous-toolchain.scm
+++ b/packages/rust-xous-toolchain.scm
@@ -50,26 +50,27 @@
     (file-name "rust-xous-source")
     (sha256 (base32 %rust-xous-guix-hash))))
 
-;;; LLVM compiler-rt source (needed for builtins)
-;;; Fetched separately to avoid the 2GB+ recursive llvm-project fetch.
-;;; From betrusted-io/rust 1.93.0-xous .gitmodules: rust-lang/llvm-project branch rustc/21.1-2025-08-01
+;;; LLVM compiler-rt source (needed for builtins).  The whole llvm-project is
+;;; fetched (only compiler-rt/ is used) to avoid the recursive submodule fetch.
+;;; Commit + hash are the betrusted-io/rust fork's gitlink for src/llvm-project,
+;;; derived into xous-config.scm by update-config.scm.
 (define llvm-compiler-rt-source
   (origin
     (method git-fetch)
     (uri (git-reference (url "https://github.com/rust-lang/llvm-project")
-                        (commit "rustc/21.1-2025-08-01")))
+                        (commit %llvm-compiler-rt-commit)))
     (file-name "llvm-compiler-rt-source")
-    (sha256 (base32 "1ay736pskcf4fzrdqw9kw5z6dskf329hjxw4xyk88g688nmzbzmi"))))
+    (sha256 (base32 %llvm-compiler-rt-guix-hash))))
 
-;;; Backtrace-rs source (needed for std's backtrace support)
-;;; Commit from betrusted-io/rust 1.90.0-xous submodule reference
+;;; Backtrace-rs source (needed for std's backtrace support).  Commit + hash
+;;; are the fork's gitlink for library/backtrace, derived into xous-config.scm.
 (define backtrace-rs-source
   (origin
     (method git-fetch)
     (uri (git-reference (url "https://github.com/rust-lang/backtrace-rs")
-                        (commit "b65ab935fb2e0d59dba8966ffca09c9cc5a5f57c")))
+                        (commit %backtrace-rs-commit)))
     (file-name "backtrace-rs-source")
-    (sha256 (base32 "1rymm0cxx6ypjazxjps9w59qkw90rx6594w4ayxjym1a17p78vvw"))))
+    (sha256 (base32 %backtrace-rs-guix-hash))))
 
 ;;; RISC-V 32-bit bare-metal cross toolchain (needed for build)
 (define riscv32-none-elf-gcc
@@ -82,7 +83,7 @@
 (define-public rust-sysroot-riscv32imac-xous-elf
   (package
     (name "rust-sysroot-riscv32imac-xous-elf")
-    (version (string-append %rust-version ".0"))
+    (version (package-version %rust))
     (source
      rust-xous-source)
     (build-system cargo-build-system)
@@ -269,7 +270,7 @@ applications.  This package propagates lld-18 as the linker.")
 (define-public rust-sysroot-merged
   (package
     (name "rust-sysroot-merged")
-    (version (string-append %rust-version ".0"))
+    (version (package-version %rust))
     (source
      #f)
     (build-system trivial-build-system)
@@ -316,7 +317,7 @@ targets for Xous development.")
 (define-public rust-xous-toolchain
   (package
     (name "rust-xous-toolchain")
-    (version (string-append %rust-version ".0"))
+    (version (package-version %rust))
     (source
      #f)
     (build-system trivial-build-system)

--- a/packages/xous-config.scm
+++ b/packages/xous-config.scm
@@ -10,7 +10,11 @@
                          %xous-owner
                          %rust-version
                          %rust-xous-commit
-                         %rust-xous-guix-hash))
+                         %rust-xous-guix-hash
+                         %llvm-compiler-rt-commit
+                         %llvm-compiler-rt-guix-hash
+                         %backtrace-rs-commit
+                         %backtrace-rs-guix-hash))
 
 ;; GitHub owner (user or org)
 (define %xous-owner
@@ -33,3 +37,15 @@
   "2ae864f7d4d42c73ab05f5e01265ea31ae81a86e")
 (define %rust-xous-guix-hash
   "0lh2ja680clqc5clcch8av8505rk5s71nkdg21yj4c7w5h24bmay")
+
+;; betrusted-io/rust submodule pins (compiler-rt + backtrace).
+;; Commits are the fork's gitlinks (src/llvm-project, library/backtrace);
+;; hashes are `guix hash -rx` of those checkouts.  Derived by update-config.scm.
+(define %llvm-compiler-rt-commit
+  "85a90d119deb25b518867cd37d62c7b93b575a6f")
+(define %llvm-compiler-rt-guix-hash
+  "03wi07w42267vj2jr2s9hakssvidskfrl1nlw3n8swfwl0jnd8hf")
+(define %backtrace-rs-commit
+  "b65ab935fb2e0d59dba8966ffca09c9cc5a5f57c")
+(define %backtrace-rs-guix-hash
+  "1rymm0cxx6ypjazxjps9w59qkw90rx6594w4ayxjym1a17p78vvw")

--- a/update-config.scm
+++ b/update-config.scm
@@ -79,8 +79,20 @@
       (lambda (port)
         (put-string port updated)))))
 
-(define (update-repo! commit url owner upstream-url vars)
-  "Clone repo, compute hash and git-describe, update config vars."
+(define (read-config-var var)
+  "Return the current string value of VAR in the config file, or #f."
+  (let* ((content (call-with-input-file %config-file get-string-all))
+         (m (string-match (string-append "\\(define " var "[ \n]+\"([^\"]*)\"")
+                          content)))
+    (and m (match:substring m 1))))
+
+(define* (update-repo! commit url owner upstream-url vars
+                       #:key (submodules '()) (derive-submodules? #t))
+  "Clone repo, compute hash and git-describe, update config vars.
+SUBMODULES is a list of (PATH COMMIT-VAR HASH-VAR): when DERIVE-SUBMODULES?
+is true, init each submodule (at the gitlink the superproject records) and
+write its commit + guix hash.  Skipping avoids the costly llvm-project fetch
+when the superproject commit has not changed."
   (let ((tmpdir (make-temp-dir))
         (start-dir (getcwd))
         (need-describe? (assoc-ref vars 'describe)))
@@ -99,15 +111,40 @@
             (run-git "fetch" "--tags" "upstream")))
         (run-git "fetch" "origin" commit)
         (run-git "-c" "advice.detachedHead=false" "checkout" commit)
-        (let ((describe (if need-describe?
-                            (run-command "git describe --long --abbrev=9")
-                            #f))
-              (hash (run-command "guix hash -rx .")))
+        (let* ((describe (if need-describe?
+                             (run-command "git describe --long --abbrev=9")
+                             #f))
+               (hash (run-command "guix hash -rx ."))
+               ;; Submodule pins are gitlinks recorded by the superproject.
+               ;; init each at that exact commit and hash its contents.
+               (sub-results
+                (if (and (pair? submodules) derive-submodules?)
+                    (begin
+                      (apply run-git "submodule" "update" "--init" "--depth" "1"
+                             (map car submodules))
+                      (map (lambda (s)
+                             (let ((path (car s))
+                                   (commit-var (cadr s))
+                                   (hash-var (caddr s)))
+                               (list path commit-var
+                                     (run-command
+                                      (string-append "git -C " path
+                                                     " rev-parse HEAD"))
+                                     hash-var
+                                     (run-command
+                                      (string-append "guix hash -rx " path)))))
+                           submodules))
+                    '())))
           (format #t "~%")
           (format #t "  commit:  ~a~a~a~%" %red commit %reset)
           (when describe
             (format #t "  version: ~a~a~a~%" %green describe %reset))
           (format #t "  hash:    ~a~a~a~%" %cyan hash %reset)
+          (for-each (lambda (r)
+                      (format #t "  ~a:~%" (car r))
+                      (format #t "    commit: ~a~a~a~%" %red (caddr r) %reset)
+                      (format #t "    hash:   ~a~a~a~%" %cyan (list-ref r 4) %reset))
+                    sub-results)
           (format #t "~%")
           (chdir start-dir)
           ;; Update config variables
@@ -115,6 +152,10 @@
           (when (and need-describe? describe)
             (update-config! need-describe? describe))
           (update-config! (assoc-ref vars 'hash) hash)
+          (for-each (lambda (r)
+                      (update-config! (cadr r) (caddr r))     ;commit-var
+                      (update-config! (list-ref r 3) (list-ref r 4))) ;hash-var
+                    sub-results)
           (format #t "~a✓ Updated ~a~a~%~%" %cyan %config-file %reset)))
       (lambda ()
         (chdir start-dir)
@@ -153,14 +194,33 @@
                     '((commit . "%xous-commit")
                       (describe . "%xous-git-describe")
                       (hash . "%xous-guix-hash")))
-      ;; Update rust-xous
+      ;; Update rust-xous (and its compiler-rt / backtrace submodule pins).
+      ;; The submodule pins are gitlinks inside the fork, so they only change
+      ;; when the fork commit changes — derive them only then, to avoid the
+      ;; ~2.4 GB llvm-project fetch on every run.  Force a re-derivation by
+      ;; clearing %llvm-compiler-rt-guix-hash in xous-config.scm.
       (format #t "~%~a=== Updating betrusted-io/rust ===~a~%" %green %reset)
-      (update-repo! rust-commit
-                    "https://github.com/betrusted-io/rust"
-                    "betrusted-io"
-                    #f
-                    '((commit . "%rust-xous-commit")
-                      (describe . #f)
-                      (hash . "%rust-xous-guix-hash"))))))
+      (let* ((old-rust-commit (read-config-var "%rust-xous-commit"))
+             (old-rt-hash (read-config-var "%llvm-compiler-rt-guix-hash"))
+             (derive? (or (not old-rust-commit)
+                          (not (string=? old-rust-commit rust-commit))
+                          (not old-rt-hash)
+                          (string=? old-rt-hash ""))))
+        (unless derive?
+          (format #t "  ~asubmodule pins unchanged (rust-xous commit same); skipping~a~%"
+                  %blue %reset))
+        (update-repo! rust-commit
+                      "https://github.com/betrusted-io/rust"
+                      "betrusted-io"
+                      #f
+                      '((commit . "%rust-xous-commit")
+                        (describe . #f)
+                        (hash . "%rust-xous-guix-hash"))
+                      #:submodules
+                      '(("src/llvm-project" "%llvm-compiler-rt-commit"
+                         "%llvm-compiler-rt-guix-hash")
+                        ("library/backtrace" "%backtrace-rs-commit"
+                         "%backtrace-rs-guix-hash"))
+                      #:derive-submodules? derive?)))))
 
 (main (command-line))


### PR DESCRIPTION
Problem: The compiler-rt and backtrace submodule pins (commit and guix hash) were hardcoded as literals in rust-xous-toolchain.scm, so a Rust fork bump required hand-editing them, and the package version fields used a synthetic "<series>.0" instead of the real patch release.

Solution: update-config.scm now inits each submodule at the gitlink the fork records and writes its commit and `guix hash -rx` into xous-config.scm, skipping the ~2.4 GB llvm-project fetch when the fork commit is unchanged.  rust-xous-toolchain.scm reads those vars and uses (package-version %rust) for its version fields.