### PR TITLE
build: bump Rust toolchain to 1.94

### DIFF
--- a/baobit.toml
+++ b/baobit.toml
@@ -12,5 +12,5 @@ owner = "betrusted-io"
 commit = "b439d312a45479419fb8853481ce92269eecf7ff"
 
 [rust-xous]
-version = "1.93"
-commit = "2ae864f7d4d42c73ab05f5e01265ea31ae81a86e"
+version = "1.94"
+commit = "fa8d53c5ed77e1707686acf94b0569cbed37696b"

--- a/packages/xous-config.scm
+++ b/packages/xous-config.scm
@@ -29,22 +29,22 @@
 ;; Rust toolchain version (e.g., "1.90", "1.91")
 ;; Package modules resolve this to rust-X.YZ
 (define %rust-version
-  "1.93")
+  "1.94")
 
 ;; betrusted-io/rust fork for Xous sysroot
 ;; Must match %rust-version (e.g., 1.90.0-xous branch)
 (define %rust-xous-commit
-  "2ae864f7d4d42c73ab05f5e01265ea31ae81a86e")
+  "fa8d53c5ed77e1707686acf94b0569cbed37696b")
 (define %rust-xous-guix-hash
-  "0lh2ja680clqc5clcch8av8505rk5s71nkdg21yj4c7w5h24bmay")
+  "08v0phd73qsdz50ylksc8yln0xrym8zm53z59mfc7sfvf9nsslp4")
 
 ;; betrusted-io/rust submodule pins (compiler-rt + backtrace).
 ;; Commits are the fork's gitlinks (src/llvm-project, library/backtrace);
 ;; hashes are `guix hash -rx` of those checkouts.  Derived by update-config.scm.
 (define %llvm-compiler-rt-commit
-  "85a90d119deb25b518867cd37d62c7b93b575a6f")
+  "00d23d10dc48c6bb9d57ba96d4a748d85d77d0c7")
 (define %llvm-compiler-rt-guix-hash
-  "03wi07w42267vj2jr2s9hakssvidskfrl1nlw3n8swfwl0jnd8hf")
+  "1ay736pskcf4fzrdqw9kw5z6dskf329hjxw4xyk88g688nmzbzmi")
 (define %backtrace-rs-commit
   "b65ab935fb2e0d59dba8966ffca09c9cc5a5f57c")
 (define %backtrace-rs-guix-hash

--- a/packages/xous-sysroot-crates.scm
+++ b/packages/xous-sysroot-crates.scm
@@ -59,6 +59,10 @@
   (crate-source "libc" "0.2.177"
                 "0xjrn69cywaii1iq2lib201bhlvan7czmrm604h5qcm28yps4x18"))
 
+(define rust-libc-0.2.178
+  (crate-source "libc" "0.2.178"
+                "1490yks6mria93i3xdva1gm05cjz824g14mbv0ph32lxma6kvj9p"))
+
 (define rust-memchr-2.7.6
   (crate-source "memchr" "2.7.6"
                 "0wy29kf6pb4fbhfksjbs05jy2f32r2f3r1ga6qkmpz31k79h0azm"))
@@ -70,6 +74,10 @@
 (define rust-moto-rt-0.15.2
   (crate-source "moto-rt" "0.15.2"
                 "0cfhr15wz7iim0fwci71g14vj2d9rj0ck7n0jb5h4d9vglwbrx0b"))
+
+(define rust-moto-rt-0.16.0
+  (crate-source "moto-rt" "0.16.0"
+                "18fvnd0gqp2467dv4pplsiij1v62m4wfrq44181qw9gbvzvskbi9"))
 
 (define rust-object-0.37.3
   (crate-source "object" "0.37.3"
@@ -102,6 +110,10 @@
 (define rust-rustc-literal-escaper-0.0.5
   (crate-source "rustc-literal-escaper" "0.0.5"
                 "12s3w2mpgpjgzi6w19k6yr6vfcczkd6cv4vld514z9f5fzd2kvp4"))
+
+(define rust-rustc-literal-escaper-0.0.7
+  (crate-source "rustc-literal-escaper" "0.0.7"
+                "165id4v4qz2awa7lq2xi1hv41zfwv7nch7b8w1k79ns0ksxpms4b"))
 
 (define rust-shlex-1.3.0
   (crate-source "shlex" "1.3.0"
@@ -191,10 +203,10 @@
                                     rust-gimli-0.32.3
                                     rust-hashbrown-0.16.1
                                     rust-hermit-abi-0.5.2
-                                    rust-libc-0.2.177
+                                    rust-libc-0.2.178
                                     rust-memchr-2.7.6
                                     rust-miniz-oxide-0.8.9
-                                    rust-moto-rt-0.15.2
+                                    rust-moto-rt-0.16.0
                                     rust-object-0.37.3
                                     rust-r-efi-5.3.0
                                     rust-r-efi-alloc-2.1.0
@@ -202,7 +214,7 @@
                                     rust-rand-core-0.9.3
                                     rust-rand-xorshift-0.4.0
                                     rust-rustc-demangle-0.1.26
-                                    rust-rustc-literal-escaper-0.0.5
+                                    rust-rustc-literal-escaper-0.0.7
                                     rust-shlex-1.3.0
                                     rust-unwinding-0.2.8
                                     rust-vex-sdk-0.27.1


### PR DESCRIPTION
Problem: The Xous sysroot and toolchain are built against the betrusted-io/rust 1.93 fork.

Solution: Point baobit.toml at the 1.94.0-xous fork commit and regenerate xous-config.scm (rust hash + compiler-rt submodule pin) and xous-sysroot-crates.scm (libc, moto-rt, rustc-literal-escaper).  All firmware targets build and boot0/boot1/dabao reproduce under CHECK=1.